### PR TITLE
correct 'Maps, 'Blighted Maps' initial item data source

### DIFF
--- a/src/scripts/poe_initial.py
+++ b/src/scripts/poe_initial.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any, cast
 
-from httpx import AsyncClient, Client
+from httpx import AsyncClient
 from loguru import logger
 from pydantic import BaseModel, Field
 import pydantic

--- a/src/scripts/poe_initial.py
+++ b/src/scripts/poe_initial.py
@@ -159,7 +159,7 @@ async def save_item_data(category_item_mapping: dict[str, list[dict]]) -> None:
 
         is_currency = category == "Currency"
 
-        for entity in item_data[:10000]:
+        for entity in item_data:
             try:
                 if is_currency:
                     item_entity = CurrencyItemEntity(**entity)

--- a/src/scripts/poe_initial.py
+++ b/src/scripts/poe_initial.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any, cast
 
-from httpx import AsyncClient
+from httpx import AsyncClient, Client
 from loguru import logger
 from pydantic import BaseModel, Field
 import pydantic
@@ -68,8 +68,8 @@ CATEGORY_GROUP_MAP = {
         Category("Cluster Jewels", "ClusterJewel"),
     ],
     "Atlas": [
-        Category("Maps", "UniqueWeapon"),
-        Category("Blighted Maps", "UniqueArmour"),
+        Category("Maps", "Map"),
+        Category("Blighted Maps", "BlightedMap"),
         Category("Blight-ravaged Maps", "BlightRavagedMap"),
         Category("Scourged Maps", "ScourgedMap"),
         Category("Unique Maps", "UniqueMap"),
@@ -159,7 +159,7 @@ async def save_item_data(category_item_mapping: dict[str, list[dict]]) -> None:
 
         is_currency = category == "Currency"
 
-        for entity in item_data:
+        for entity in item_data[:10000]:
             try:
                 if is_currency:
                     item_entity = CurrencyItemEntity(**entity)


### PR DESCRIPTION
This PR corrects the `internal_name` values for the `Maps` and `Blighted Maps` PoE item categories, ensuring that they fetch the requisite map data, rather than data for other categories. This also reduces the number of records in the `Item` collection.