### PR TITLE
Modularize DB Date Fields' Logic and Denormalize `Item` Models

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,8 +4,8 @@ import beanie
 
 from .app import AppConfig
 from .users import User, BlacklistedToken
-from .poe import Item, ItemCategory, ItemPrice
+from .poe import Item, ItemCategory
 
 
 # group and export models for initializing Beanie connection
-document_models: list[Type[beanie.Document]] = [User, BlacklistedToken, AppConfig, Item, ItemCategory, ItemPrice]
+document_models: list[Type[beanie.Document]] = [User, BlacklistedToken, AppConfig, Item, ItemCategory]

--- a/src/models/common.py
+++ b/src/models/common.py
@@ -14,3 +14,6 @@ class DateMetadataDocument(Document):
     @after_event(Update, Replace, SaveChanges, ValidateOnSave)
     def update_document_time(self) -> None:
         self.updated_time = dt.datetime.now()
+
+    class Settings:
+        is_root = True

--- a/src/models/common.py
+++ b/src/models/common.py
@@ -1,0 +1,16 @@
+import datetime as dt
+
+from beanie import Document, after_event, Replace, SaveChanges, Update, ValidateOnSave
+from pydantic import Field
+
+
+class DateMetadataDocument(Document):
+    """DateMetadataDocument provides created and updated time fields, and sets the correct `updated_time` each time the
+    model instance is modified."""
+
+    created_time: dt.datetime = Field(default_factory=dt.datetime.now)
+    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)
+
+    @after_event(Update, Replace, SaveChanges, ValidateOnSave)
+    def update_document_time(self) -> None:
+        self.updated_time = dt.datetime.now()

--- a/src/models/poe.py
+++ b/src/models/poe.py
@@ -1,12 +1,10 @@
-import datetime as dt
-from decimal import Decimal
 from enum import Enum
 
 from beanie import Link
 from pydantic import Field
 
 from src.models.common import DateMetadataDocument
-from src.schemas.poe import Currency
+from src.schemas.poe import ItemPrice
 
 
 class ItemIdType(str, Enum):
@@ -29,12 +27,14 @@ class ItemCategory(DateMetadataDocument):
 
 
 class Item(DateMetadataDocument):
-    """Item represents a Path of Exile in-game item. Each item belongs to a category."""
+    """Item represents a Path of Exile in-game item. Each item belongs to a category. It contains information such as
+    item type and the current, past and predicted pricing, encapsulated in the `ItemPrice` schema."""
 
     poe_ninja_id: int
     id_type: ItemIdType | None = None
     name: str
     category: Link[ItemCategory]
+    price: ItemPrice | None
     type_: str | None = Field(None, serialization_alias="type")
     variant: str | None = None
     icon_url: str | None = None
@@ -44,21 +44,3 @@ class Item(DateMetadataDocument):
         """Defines the settings for the collection."""
 
         name = "poe_items"
-
-
-class ItemPrice(DateMetadataDocument):
-    """ItemPrice holds information regarding the current, past and future price of an item.
-    It stores the recent and predicted prices in a dictionary, with the date as the key."""
-
-    item: Link[Item]
-    price: Decimal
-    currency: Currency
-    price_history: dict[dt.datetime, Decimal]
-    price_history_currency: Currency
-    price_prediction: dict[dt.datetime, Decimal]
-    price_prediction_currency: Currency
-
-    class Settings:
-        """Defines the settings for the collection."""
-
-        name = "poe_item_prices"

--- a/src/models/poe.py
+++ b/src/models/poe.py
@@ -2,9 +2,10 @@ import datetime as dt
 from decimal import Decimal
 from enum import Enum
 
-from beanie import Document, Link, Replace, SaveChanges, Update, ValidateOnSave, after_event
+from beanie import Link
 from pydantic import Field
 
+from src.models.common import DateMetadataDocument
 from src.schemas.poe import Currency
 
 
@@ -13,20 +14,13 @@ class ItemIdType(str, Enum):
     receive = "receive"
 
 
-# TODO: see if we can modularize the created-updated time and update-time aspects
-class ItemCategory(Document):
+class ItemCategory(DateMetadataDocument):
     """ItemCategory represents a major category that items belong to. A category is the primary form of classifying
     items. Each category belongs to a category group (model not defined for category groups)."""
 
     name: str
     internal_name: str
     group: str
-    created_time: dt.datetime = Field(default_factory=dt.datetime.now)
-    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)
-
-    @after_event(Replace, SaveChanges, Update, ValidateOnSave)
-    def update_time(self):
-        self.updated_time = dt.datetime.now()
 
     class Settings:
         """Defines the settings for the collection."""
@@ -34,7 +28,7 @@ class ItemCategory(Document):
         name = "poe_item_categories"
 
 
-class Item(Document):
+class Item(DateMetadataDocument):
     """Item represents a Path of Exile in-game item. Each item belongs to a category."""
 
     poe_ninja_id: int
@@ -45,12 +39,6 @@ class Item(Document):
     variant: str | None = None
     icon_url: str | None = None
     enabled: bool = True
-    created_time: dt.datetime = Field(default_factory=dt.datetime.now)
-    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)
-
-    @after_event(Replace, SaveChanges, Update, ValidateOnSave)
-    def update_time(self):
-        self.updated_time = dt.datetime.now()
 
     class Settings:
         """Defines the settings for the collection."""
@@ -58,7 +46,7 @@ class Item(Document):
         name = "poe_items"
 
 
-class ItemPrice(Document):
+class ItemPrice(DateMetadataDocument):
     """ItemPrice holds information regarding the current, past and future price of an item.
     It stores the recent and predicted prices in a dictionary, with the date as the key."""
 
@@ -69,12 +57,6 @@ class ItemPrice(Document):
     price_history_currency: Currency
     price_prediction: dict[dt.datetime, Decimal]
     price_prediction_currency: Currency
-    created_time: dt.datetime = Field(default_factory=dt.datetime.now)
-    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)
-
-    @after_event(Replace, SaveChanges, Update, ValidateOnSave)
-    def update_time(self):
-        self.updated_time = dt.datetime.now()
 
     class Settings:
         """Defines the settings for the collection."""

--- a/src/models/users.py
+++ b/src/models/users.py
@@ -4,11 +4,12 @@ from beanie import Document, Link
 from pydantic import Field, SecretStr
 from pymongo import IndexModel
 
+from src.models.common import DateMetadataDocument
 from src.schemas.users import UserBase, UserSession
 
 
 # TODO: add user status and login attempts columns
-class User(UserBase, Document):
+class User(UserBase, DateMetadataDocument):
     """User represents a User of the application."""
 
     password: SecretStr = Field(min_length=8)

--- a/src/schemas/poe.py
+++ b/src/schemas/poe.py
@@ -1,6 +1,22 @@
+import datetime as dt
+from decimal import Decimal
 from enum import Enum
+
+from pydantic import BaseModel
 
 
 class Currency(str, Enum):
-    divines = "divines"
     chaos = "chaos"
+    divines = "divines"
+
+
+class ItemPrice(BaseModel):
+    """ItemPrice holds information regarding the current, past and future price of an item.
+    It stores the recent and predicted prices in a dictionary, with the date as the key."""
+
+    price: Decimal
+    currency: Currency
+    price_history: dict[dt.datetime, Decimal]
+    price_history_currency: Currency
+    price_prediction: dict[dt.datetime, Decimal]
+    price_prediction_currency: Currency

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -40,13 +40,21 @@ class UserUpdateInput(BaseModel):
 
 
 class UserBase(BaseModel):
-    """UserBase is the base user model, representing User instances for API responses. Omits the
-    password field for security."""
+    """UserBase is the base user model, encapsulating core-User instance data. Omits the password field for
+    security."""
 
     id: PydanticObjectId | None = None
     name: str = Field(min_length=3, max_length=255)
     email: EmailStr
     role: Role
+
+
+class UserBaseResponse(UserBase):
+    """UserBaseResponse extends UserBase and includes the created and updated datetime fields, for User API
+    responses."""
+
+    created_time: dt.datetime
+    updated_time: dt.datetime
 
 
 class UserSession(BaseModel):

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -6,7 +6,6 @@ from beanie import PydanticObjectId
 from pydantic import BaseModel, EmailStr, Field, SecretStr, validator
 
 from src.config.constants.app import PASSWORD_REGEX
-from src.models.common import DateMetadataDocument
 
 
 class Role(str, Enum):
@@ -40,7 +39,7 @@ class UserUpdateInput(BaseModel):
     email: EmailStr
 
 
-class UserBase(DateMetadataDocument):
+class UserBase(BaseModel):
     """UserBase is the base user model, representing User instances for API responses. Omits the
     password field for security."""
 
@@ -50,8 +49,9 @@ class UserBase(DateMetadataDocument):
     role: Role
 
 
-class UserSession(DateMetadataDocument):
+class UserSession(BaseModel):
     """UserSession encapsulates the user's session logic."""
 
     refresh_token: str | None
     expiration_time: dt.datetime | None
+    updated_time: dt.datetime = Field(default_factory=dt.datetime.utcnow)

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -6,6 +6,7 @@ from beanie import PydanticObjectId
 from pydantic import BaseModel, EmailStr, Field, SecretStr, validator
 
 from src.config.constants.app import PASSWORD_REGEX
+from src.models.common import DateMetadataDocument
 
 
 class Role(str, Enum):
@@ -39,7 +40,7 @@ class UserUpdateInput(BaseModel):
     email: EmailStr
 
 
-class UserBase(BaseModel):
+class UserBase(DateMetadataDocument):
     """UserBase is the base user model, representing User instances for API responses. Omits the
     password field for security."""
 
@@ -47,13 +48,10 @@ class UserBase(BaseModel):
     name: str = Field(min_length=3, max_length=255)
     email: EmailStr
     role: Role
-    created_time: dt.datetime = Field(default_factory=dt.datetime.now)
-    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)
 
 
-class UserSession(BaseModel):
+class UserSession(DateMetadataDocument):
     """UserSession encapsulates the user's session logic."""
 
     refresh_token: str | None
     expiration_time: dt.datetime | None
-    updated_time: dt.datetime = Field(default_factory=dt.datetime.now)

--- a/src/services/auth.py
+++ b/src/services/auth.py
@@ -8,7 +8,7 @@ from motor.core import AgnosticClientSession
 from starlette import status
 
 from src.models.users import User, BlacklistedToken
-from src.schemas.users import UserBase, UserSession
+from src.schemas.users import UserBase, UserBaseResponse, UserSession
 from src.services import users as users_service
 from src.utils.auth_utils import compare_values
 
@@ -30,7 +30,7 @@ async def check_users_credentials(form_data: OAuth2PasswordRequestForm) -> UserB
     if not valid_password:
         raise invalid_credentials_error
 
-    user_base = user = UserBase(
+    user_base = user = UserBaseResponse(
         id=user.id,
         name=user.name,
         email=user.email,

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -10,7 +10,7 @@ from pymongo.errors import DuplicateKeyError
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from src.models.users import User
-from src.schemas.users import Role, UserBase, UserInput, UserUpdateInput
+from src.schemas.users import Role, UserBase, UserBaseResponse, UserInput, UserUpdateInput
 from src.utils import auth_utils
 
 
@@ -46,7 +46,7 @@ async def get_users() -> list[UserBase]:
 
     # parsing User to UserBase using parse_obj to avoid `id` loss -- pydantic V2 bug
     for user_record in user_records:
-        user = UserBase(
+        user = UserBaseResponse(
             id=user_record.id,
             name=user_record.name,
             email=user_record.email,
@@ -98,7 +98,7 @@ async def get_user(
         user_record = await get_user_from_database(None, user_email, missing_user_error=missing_user_error)
 
     user_record = cast(User, user_record)
-    user = UserBase(
+    user = UserBaseResponse(
         id=user_record.id,
         name=user_record.name,
         email=user_record.email,

--- a/src/tests/routers/conftest.py
+++ b/src/tests/routers/conftest.py
@@ -9,7 +9,7 @@ from typing import Any, AsyncGenerator
 
 from src import main
 from src.models.users import BlacklistedToken, User
-from src.schemas.users import Role, UserBase
+from src.schemas.users import Role, UserBase, UserBaseResponse
 from src.utils.auth_utils import hash_value
 
 
@@ -46,7 +46,7 @@ async def test_user() -> AsyncGenerator[User | UserBase, Any]:
     except (beanie.exceptions.RevisionIdWasChanged, beanie.exceptions.DocumentAlreadyCreated):
         pass
 
-    user_base = UserBase(
+    user_base = UserBaseResponse(
         id=user.id,
         name="backend_burger_test",
         email=EMAIL,


### PR DESCRIPTION
This PR modularizes the existing DB schema by creating a dedicated DB model instance for common date fields, and the `updated_date` field, which should be updated each time the a document is modified.
It also denormalizes the `ItemPrice` DB Model by converting it to be  a part of the `Item` model.