### PR TITLE
Fix PoE Models' Issues

### DIFF
--- a/src/models/common.py
+++ b/src/models/common.py
@@ -14,6 +14,3 @@ class DateMetadataDocument(Document):
     @after_event(Update, Replace, SaveChanges, ValidateOnSave)
     def update_document_time(self) -> None:
         self.updated_time = dt.datetime.now()
-
-    class Settings:
-        is_root = True

--- a/src/models/poe.py
+++ b/src/models/poe.py
@@ -34,7 +34,7 @@ class Item(DateMetadataDocument):
     id_type: ItemIdType | None = None
     name: str
     category: Link[ItemCategory]
-    price: ItemPrice | None
+    price: ItemPrice | None = None
     type_: str | None = Field(None, serialization_alias="type")
     variant: str | None = None
     icon_url: str | None = None


### PR DESCRIPTION
- fix db models inheriting from `DateMetadataDocument` not using their respective collections for data manipulation
- default to `None` for `Item` model's `price` field; this allows us to skip assignment when initializing model instance