### PR TITLE
Refactor PoE Initial Data Entry Script's Flow

### DIFF
--- a/src/models/common.py
+++ b/src/models/common.py
@@ -14,6 +14,3 @@ class DateMetadataDocument(Document):
     @after_event(Update, Replace, SaveChanges, ValidateOnSave)
     def update_document_time(self) -> None:
         self.updated_time = dt.datetime.now()
-
-    class Settings:
-        is_root = True

--- a/src/models/poe.py
+++ b/src/models/poe.py
@@ -34,7 +34,7 @@ class Item(DateMetadataDocument):
     id_type: ItemIdType | None = None
     name: str
     category: Link[ItemCategory]
-    price: ItemPrice | None
+    price: ItemPrice | None = None
     type_: str | None = Field(None, serialization_alias="type")
     variant: str | None = None
     icon_url: str | None = None

--- a/src/scripts/poe_initial.py
+++ b/src/scripts/poe_initial.py
@@ -281,12 +281,14 @@ async def parse_api_item_data(
                     logger.error(f"no pay or get id found for {item_entity.currencyTypeName}, skipping")
                     continue
 
+                item_metadata = item_entity.metadata
                 item_record = Item(
                     poe_ninja_id=poe_ninja_id,
                     id_type=id_type,
                     name=item_entity.currencyTypeName,
-                    category=category_record,  # type: ignore
                     type_=None,
+                    category=category_record,  # type: ignore
+                    icon_url=item_metadata.icon if item_metadata else None,
                 )
 
             else:


### PR DESCRIPTION
The initial script that loads data requires few improvements, not counting the schema updates required to make the following changes possible:

- [x] add icon urls for items belonging to the `Currency` category
- [x] refactor API item data parsing logic into separate function
- [x] refactor pydantic to db model conversion logic into separate function