### PR TITLE
Restrict CI Job's Maximum Duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ env:
 
 jobs:
     build:
+        timeout-minutes: 15
         runs-on: ubuntu-latest
         
         services:


### PR DESCRIPTION
This will help ensure that any failed step doesn't cause long-running tmate sessions.