### PR TITLE
Fix Github Workflows Failing due to Logfire

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+env:
+    APP_ENVIRONMENT: github_workflow
+
 jobs:
     deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ env:
     S3_BUCKET_NAME: ${{secrets.S3_BUCKET_NAME}}
     S3_LOGS_FOLDER: ${{secrets.S3_LOGS_FOLDER}}
     REDIS_HOST: localhost
+    APP_ENVIRONMENT: github_workflow
 
 jobs:
     build:

--- a/src/config/services.py
+++ b/src/config/services.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
 
     redis_host: str
     redis_password: SecretStr | None = None
+    app_environment: str
 
 
 def generate_settings_config(env_location: str | None = None) -> Settings:
@@ -75,6 +76,10 @@ def generate_settings_config(env_location: str | None = None) -> Settings:
 
 def initialize_logfire_services(app: FastAPI) -> None:
     """Initializes LogFire services by configuring and initializing its client, and registering requisite services."""
+
+    # skip as requisite env vars wont be available
+    if settings.app_environment == "github_workflow":
+        return
 
     logfire.configure()
     logfire.instrument_fastapi(app)


### PR DESCRIPTION
Disabling Pydantic Logfire initialization during Github workflows to avoid runtime errors.