### PR TITLE
Fix Nested Filter-Sort and Model Querying Issues

### DIFF
--- a/src/config/constants/app.py
+++ b/src/config/constants/app.py
@@ -1,8 +1,10 @@
 from typing import Literal
 from uuid import uuid4
 import datetime as dt
+import operator
 
 from beanie.odm.interfaces.find import FindType, DocumentProjectionType
+from beanie.odm.operators.find.evaluation import RegEx as RegExOperator
 from beanie.odm.queries.find import FindMany
 
 
@@ -31,3 +33,13 @@ SORT_OPERATION = Literal["asc", "desc"]
 FIND_MANY_QUERY = FindMany[FindType] | FindMany[DocumentProjectionType]
 
 FILTER_OPERATION = Literal["=", "!=", ">", ">=", "<", "<=", "like"]
+
+FILTER_OPERATION_MAP = {
+    "=": operator.eq,
+    "!=": operator.ne,
+    ">": operator.gt,
+    "<": operator.lt,
+    ">=": operator.ge,
+    "<=": operator.le,
+    "like": RegExOperator,
+}

--- a/src/config/constants/app.py
+++ b/src/config/constants/app.py
@@ -33,7 +33,6 @@ SORT_OPERATION = Literal["asc", "desc"]
 FIND_MANY_QUERY = FindMany[FindType] | FindMany[DocumentProjectionType]
 
 FILTER_OPERATION = Literal["=", "!=", ">", ">=", "<", "<=", "like"]
-
 FILTER_OPERATION_MAP = {
     "=": operator.eq,
     "!=": operator.ne,
@@ -42,4 +41,11 @@ FILTER_OPERATION_MAP = {
     ">=": operator.ge,
     "<=": operator.le,
     "like": RegExOperator,
+}
+NESTED_FILTER_OPERATION_MAP = {
+    "=": "$eq",
+    ">": "$gt",
+    ">=": "$gte",
+    "<": "$lt",
+    "<=": "$lte",
 }

--- a/src/utils/services.py
+++ b/src/utils/services.py
@@ -1,5 +1,4 @@
 import copy
-import operator
 from typing import Self, Type, cast
 
 from beanie import Document
@@ -9,7 +8,7 @@ import orjson
 import pymongo
 from redis.asyncio import Redis, RedisError
 
-from src.config.constants.app import FIND_MANY_QUERY
+from src.config.constants.app import FILTER_OPERATION_MAP, FIND_MANY_QUERY
 from src.schemas.requests import FilterInputType, FilterSchema, PaginationInput, SortInputType, SortSchema
 from src.schemas.responses import E, T, BaseResponse
 
@@ -89,20 +88,10 @@ def filter_on_query(query: FIND_MANY_QUERY, model: Type[Document], filter_: Filt
     if not isinstance(filter_, list):
         return query
 
-    operation_map = {
-        "=": operator.eq,
-        "!=": operator.ne,
-        ">": operator.gt,
-        "<": operator.lt,
-        ">=": operator.ge,
-        "<=": operator.le,
-        "like": RegExOperator,
-    }
-
     for entry in filter_:
         field = entry.field
         operation = entry.operation
-        operation_function = operation_map[operation]
+        operation_function = FILTER_OPERATION_MAP[operation]
         value = entry.value
 
         model_field = getattr(model, field)

--- a/src/utils/services.py
+++ b/src/utils/services.py
@@ -71,7 +71,8 @@ def sort_on_query(query: FIND_MANY_QUERY, model: Type[Document], sort: SortInput
         field = entry.field
         operation = pymongo.ASCENDING if entry.operation == "asc" else pymongo.DESCENDING
 
-        model_field = getattr(model, field)
+        is_nested = "." in field
+        model_field = field if is_nested else getattr(model, field)
         expression = (model_field, operation)
 
         sort_expressions.append(expression)


### PR DESCRIPTION
PR #25's changes broke filter and sort functionality for nested columns. This PR addresses those issues by using raw Mongo syntax and avoiding extracting model attributes for such filter/sort parameters.
This also prevents duplication of filter-sort parameters on successive queries that happened due to the re-use of the same `query` object for both `count` and the actual fetch queries.