### PR TITLE
Modify Price Prediction Logic

### DIFF
--- a/src/services/poe.py
+++ b/src/services/poe.py
@@ -65,4 +65,9 @@ async def get_items(
         logger.error(f"error getting items from database; filter_sort: {filter_sort_input}: {exc}")
         raise
 
+    # limit price history data to past last 7 days' data
+    for item in items:
+        if item.price_info is not None and item.price_info.price_history:
+            item.price_info.price_history = item.price_info.price_history[-7:]
+
     return items, items_count


### PR DESCRIPTION
- Brings price prediction script up-to-date with latest application changes.
- Also prevents duplication of price history records, and errors during price history API calls in the script flow.
- Modifies items API to return last 7 price history data records, since that is the data-set used by the frontend currently.